### PR TITLE
Add separate user and udev-rule

### DIFF
--- a/etc/systemd/pylarexx.service
+++ b/etc/systemd/pylarexx.service
@@ -5,6 +5,8 @@ Description=Python Logger Arexx Daemon
 Type=simple
 ExecStart=/usr/local/pylarexx/pylarexx.py -f /etc/pylarexx.yml
 WorkingDirectory=/usr/local/pylarexx
+User=pylarexx
+Group=pylarexx
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/udev/rules.d/51-rf_usb.rules
+++ b/etc/udev/rules.d/51-rf_usb.rules
@@ -1,0 +1,3 @@
+# udev rules to match temperature logger and grant daemon user "pylarexx" permission to access it
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0451", ATTRS{idProduct}=="3211", GROUP="pylarexx", MODE="0664" 
+

--- a/install.sh
+++ b/install.sh
@@ -2,12 +2,16 @@
 
 echo "Installing pylarexx in /usr/local/pylarexx"
 mkdir -p /usr/local/pylarexx
-cp -r pylarexx.py datalogger /usr/local/pylarexx
+cp -r pylarexx.py deviceinfo.xml datalogger /usr/local/pylarexx
 echo "Placing example config to /etc/pylarexx.yml"
 cp example_pylarexx.yml /etc/pylarexx.yml
 if [ -f /usr/bin/systemctl ] ; then
+  echo "Add user pylarexx to run daemon"
+  useradd pylarexx --system --user-group --home-dir /var/run/arexx/
+  echo "Install udev rule to allow daemon device access"
+  cp etc/udev/rules.d/51-rf_usb.rules /etc/udev/rules.d/
   echo "Creating pylarexx systemd service. Start it with: systemctl start pylarexx"
   echo "Start at boot with: systemctl enable pylarexx"
-  cp systemd/pylarexx.service /etc/systemd/system
+  cp etc/systemd/pylarexx.service /etc/systemd/system
   systemctl daemon-reload
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ pyusb
 paho-mqtt
 influxdb
 pyaml
+
+# or on openSUSE 15.1
+python3-usb
+python3-pyaml


### PR DESCRIPTION
- add user "pylarexx" and group "pylarexx" while installing
- modified udev rule to give group "pylarexx" read and write permission
to usb data logger
- modified systemd unit file to run daemon as user "pylarexx"
- move /etc/ files into etc/ folder (udev and systemd)
- add hint to required packages on openSUSE systems